### PR TITLE
Refactoring to support :scope... 

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,23 @@ end
 
 When you create new features for your app & try them out in development mode, `config/active_params.json` will be automatically updated. When you commit your code, include the changes to `config/active_params.json` too.
 
-### Customizations
+### Static Customizations
 
-Include instead with `ActiveParams.setup`,
+You can add a `config/initializers/active_params.rb` file in your Rails app, and perform a global config like this
+
+```ruby
+ActiveParams.config do |config|
+  config.writing = Rails.env.development?
+  config.path    = "config/active_params.json"
+  config.scope   = proc { |controller|
+    "#{controller.request.method} #{controller.controller_name}/#{controller.action_name}"
+  }
+end
+```
+
+### Dynamic Customizations
+
+Each controller may need its own config, e.g. some strong params are only permitted for certain current_user roles. For such controllers, use the `include ActiveParams.setup(...)` syntax instead
 
 ```ruby
 class ApplicationController < ActionController::Base
@@ -101,7 +115,7 @@ class ApplicationController < ActionController::Base
     path: "tmp/strong_params.json",
     writing: !Rails.env.production?,
     scope: proc {|ctrl|
-      [ctrl.current_user.role, ctrl.active_params_default_scope].join('@')
+      [ctrl.current_user.role, ActiveParams.scope.(ctrl)].join('@')
     },
   })
 end

--- a/README.md
+++ b/README.md
@@ -91,6 +91,27 @@ end
 
 When you create new features for your app & try them out in development mode, `config/active_params.json` will be automatically updated. When you commit your code, include the changes to `config/active_params.json` too.
 
+### Customizations
+
+Include instead with `ActiveParams.setup`,
+
+```ruby
+class ApplicationController < ActionController::Base
+  include ActiveParams.setup({
+    path: "tmp/strong_params.json",
+    writing: !Rails.env.production?,
+    scope: proc {|ctrl|
+      [ctrl.current_user.role, ctrl.active_params_default_scope].join('@')
+    },
+  })
+end
+```
+
+You can setup
+- where the config file is stored
+- if you want to write to the config file
+- how should strong params be scoped
+
 ## LICENSE
 
 MIT

--- a/lib/active_params.rb
+++ b/lib/active_params.rb
@@ -3,19 +3,36 @@ require "active_params/parser"
 require "active_params/controller"
 
 module ActiveParams
-  # `include ActiveParams` use default settings
-  def self.included(base)
-    base.send(:include, setup)
-  end
+  class << self
+    attr_accessor :writing, :path, :scope
 
-  # `include ActiveParams.setup({...})` customize
-  def self.setup(options = {})
-    Module.new do
-      def self.included(base)
-        base.send(:include, ActiveParams::Controller)
+    # ActiveParams.config {|c| .... }
+    def config
+      yield self
+    end
+
+    # `include ActiveParams` use default settings
+    def included(base)
+      base.send(:include, setup)
+    end
+
+    # `include ActiveParams.setup({...})` customize
+    def setup(options = {})
+      Module.new do
+        def self.included(base)
+          base.send(:include, ActiveParams::Controller)
+        end
+      end.tap do |m|
+        m.send(:define_method, :active_params_options) { options }
       end
-    end.tap do |m|
-      m.send(:define_method, :active_params_options) { options }
     end
   end
+end
+
+ActiveParams.config do |config|
+  config.writing = defined?(Rails) && Rails.env.development?
+  config.path    = "config/active_params.json"
+  config.scope   = proc { |controller|
+    "#{controller.request.method} #{controller.controller_name}/#{controller.action_name}"
+  }
 end

--- a/lib/active_params.rb
+++ b/lib/active_params.rb
@@ -1,86 +1,21 @@
 require "active_params/version"
+require "active_params/parser"
+require "active_params/controller"
 
 module ActiveParams
-  def write_strong_params(global_config: ActiveParams.global_config)
-    current_config = global_config["#{request.method} #{controller_name}/#{action_name}"] ||= {}
-    params.each do |k,v|
-      case result = ActiveParams.strong_params_definition_for(v)
-      when Array, Hash
-        current_config[k] = result
-      end
-    end
-    open(ActiveParams.path, "wb") {|f| f.write(JSON.pretty_generate(global_config)) }
-    yield
-  end
-
-  def apply_strong_params(global_config: ActiveParams.global_config)
-    # e.g. POST users#update
-    current_config = global_config["#{request.method} #{controller_name}/#{action_name}"] ||= {}
-    params.each do |k,v|
-      if result = current_config[k]
-        params[k] = params.require(k).permit(result)
-      end
-    end
-    yield
-  end
-
+  # `include ActiveParams` use default settings
   def self.included(base)
-    if base.methods.include? :around_action
-      base.class_eval do
-        around_action :write_strong_params if ActiveParams.development_mode?
-        around_action :apply_strong_params
+    base.send(:include, setup)
+  end
+
+  # `include ActiveParams.setup({...})` customize
+  def self.setup(options = {})
+    Module.new do
+      def self.included(base)
+        base.send(:include, ActiveParams::Controller)
       end
-    end
-  end
-
-  def self.development_mode?
-    defined?(Rails) && Rails.env.development?
-  end
-
-  def self.path
-    ENV.fetch("ACTIVE_PARAMS_PATH", "config/active_params.json")
-  end
-
-  def self.global_config
-    @@global_config ||= (File.exists?(ActiveParams.path) ? JSON.parse(IO.read ActiveParams.path) : {})
-  ensure
-    # undo cache in development mode
-    @@global_config = nil if development_mode?
-  end
-
-  # to obtain a hash of all possible keys
-  def self.combine_hashes(array_of_hashes)
-    array_of_hashes.select {|v| v.kind_of?(Hash) }.
-      inject({}) {|sum, hash| hash.inject(sum) {|sum,(k,v)| sum.merge(k => v) } }
-  end
-
-  def self.strong_params_definition_for(params)
-    if params.kind_of?(Array)
-      combined_hash = combine_hashes(params)
-      if combined_hash.empty?
-        []
-      else
-        strong_params_definition_for(combined_hash)
-      end
-    elsif params.respond_to?(:keys) # Hash, ActionController::Parameters
-      values, arrays = [[], {}]
-      params.each do |key, value|
-        case value
-        when Array
-          arrays[key] = strong_params_definition_for(value)
-        when Hash
-          arrays[key] = strong_params_definition_for(combine_hashes(value.values))
-        else
-          values.push(key)
-        end
-      end
-      if arrays.empty?
-        values
-      else
-        [*values.sort, arrays]
-      end
-    else
-      params
+    end.tap do |m|
+      m.send(:define_method, :active_params_options) { options }
     end
   end
 end

--- a/lib/active_params/controller.rb
+++ b/lib/active_params/controller.rb
@@ -1,0 +1,69 @@
+require "json"
+
+module ActiveParams
+  module Controller
+    def self.included(base)
+      add_before_method =
+        (base.methods.include?(:before_action) && :before_action) ||
+        (base.methods.include?(:before_filter) && :before_filter)
+
+      if add_before_method
+        base.class_eval do
+          send add_before_method, :active_params_write, if: :active_params_writing?
+          send add_before_method, :active_params_apply
+        end
+      end
+    end
+
+    def active_params_writing?
+      active_params_options[:writing] || defined?(Rails) && Rails.env.development?
+    end
+
+    def active_params_path
+      active_params_options[:path] || ENV.fetch("ACTIVE_PARAMS_PATH", "config/active_params.json")
+    end
+
+    def active_params_json
+      @@active_params_json ||= (File.exists?(active_params_path) ? JSON.parse(IO.read active_params_path) : {})
+    rescue JSON::ParserError
+      return {}
+    ensure
+      # undo cache in development mode
+      @@active_params_json = nil if active_params_writing?
+    end
+
+    def active_params_scope
+      scope = active_params_options[:scope]
+      if scope.respond_to?(:call)
+        scope.call(self)
+      else
+        active_params_default_scope
+      end
+    end
+
+    def active_params_default_scope
+      "#{request.method} #{controller_name}/#{action_name}"
+    end
+
+    def active_params_write(global_json: active_params_json)
+      scoped_json = global_json[active_params_scope] ||= {}
+      params.each do |k,v|
+        case result = ActiveParams::Parser.strong_params_definition_for(v)
+        when Array, Hash
+          scoped_json[k] = result
+        end
+      end
+      open(active_params_path, "wb") {|f| f.write(JSON.pretty_generate(global_json)) }
+    end
+
+    def active_params_apply(global_json: active_params_json)
+      # e.g. POST users#update
+      scoped_json = global_json[active_params_scope] ||= {}
+      params.each do |k,v|
+        if result = scoped_json[k]
+          params[k] = params.require(k).permit(result)
+        end
+      end
+    end
+  end
+end

--- a/lib/active_params/controller.rb
+++ b/lib/active_params/controller.rb
@@ -16,11 +16,11 @@ module ActiveParams
     end
 
     def active_params_writing?
-      active_params_options[:writing] || defined?(Rails) && Rails.env.development?
+      active_params_options[:writing] || ActiveParams.writing
     end
 
     def active_params_path
-      active_params_options[:path] || ENV.fetch("ACTIVE_PARAMS_PATH", "config/active_params.json")
+      active_params_options[:path] || ActiveParams.path
     end
 
     def active_params_json
@@ -33,16 +33,8 @@ module ActiveParams
     end
 
     def active_params_scope
-      scope = active_params_options[:scope]
-      if scope.respond_to?(:call)
-        scope.call(self)
-      else
-        active_params_default_scope
-      end
-    end
-
-    def active_params_default_scope
-      "#{request.method} #{controller_name}/#{action_name}"
+      scope = active_params_options[:scope] || ActiveParams.scope
+      scope.respond_to?(:call) ? scope.(self) : scope
     end
 
     def active_params_write(global_json: active_params_json)

--- a/lib/active_params/parser.rb
+++ b/lib/active_params/parser.rb
@@ -1,0 +1,41 @@
+module ActiveParams
+  module Parser
+    # to obtain a hash of all possible keys
+    def combine_hashes(array_of_hashes)
+      array_of_hashes.select {|v| v.kind_of?(Hash) }.
+        inject({}) {|sum, hash| hash.inject(sum) {|sum,(k,v)| sum.merge(k => v) } }
+    end
+
+    def strong_params_definition_for(params)
+      if params.kind_of?(Array)
+        combined_hash = combine_hashes(params)
+        if combined_hash.empty?
+          []
+        else
+          strong_params_definition_for(combined_hash)
+        end
+      elsif params.respond_to?(:keys) # Hash, ActionController::Parameters
+        values, arrays = [[], {}]
+        params.each do |key, value|
+          case value
+          when Array
+            arrays[key] = strong_params_definition_for(value)
+          when Hash
+            arrays[key] = strong_params_definition_for(combine_hashes(value.values))
+          else
+            values.push(key)
+          end
+        end
+        if arrays.empty?
+          values
+        else
+          [*values.sort, arrays]
+        end
+      else
+        params
+      end
+    end
+
+    self.extend(self)
+  end
+end

--- a/lib/active_params/version.rb
+++ b/lib/active_params/version.rb
@@ -1,3 +1,3 @@
 module ActiveParams
-  VERSION = "0.1.1"
+  VERSION = "1.0.0"
 end

--- a/test/active_params/parser_test.rb
+++ b/test/active_params/parser_test.rb
@@ -1,0 +1,56 @@
+require 'test_helper'
+
+class ActiveParams::ParserTest < Minitest::Test
+  include ActiveParams::Parser
+
+  def test_strong_params_definition_for_number
+    assert_equal 123,
+      strong_params_definition_for(123)
+  end
+
+  def test_strong_params_definition_for_string
+    assert_equal "123",
+      strong_params_definition_for("123")
+  end
+
+  def test_strong_params_definition_for_array
+    assert_equal [],
+      strong_params_definition_for([123, "123"])
+  end
+
+  def test_strong_params_definition_for
+    assert_equal [:id, :name, contacts: [:name, :relation, contacts: [:relation, :name], addresses: [:label, :address]], interests: []],
+      strong_params_definition_for({
+        id: rand,
+        name: "Lorem ipsum",
+        contacts: {
+          "0" => {
+            relation: "Friend",
+            name: "Bob",
+          },
+          "1" => {
+            relation: "Mother",
+            name: "Charlie",
+            contacts: {
+              "0" => {
+                relation: "Friend",
+                name: "David",
+              },
+              "1" => {
+                relation: "Friend",
+                name: "Ethan",
+              },
+            },
+            addresses: [
+              { label: "home", address: "123 Sesame Street, NY" },
+              { label: "work", address: "Lorem ipsum"},
+            ]
+          },
+        },
+        interests: [
+          "Running",
+          "Netflix",
+        ]
+      })
+  end
+end

--- a/test/active_params_test.rb
+++ b/test/active_params_test.rb
@@ -5,54 +5,42 @@ class ActiveParamsTest < Minitest::Test
     refute_nil ::ActiveParams::VERSION
   end
 
-  def test_strong_params_definition_for_number
-    assert_equal 123,
-      ActiveParams.strong_params_definition_for(123)
+  # `include ActiveParams`
+  def test_defalut
+    value = rand
+    klass = Class.new do
+      include ActiveParams
+    end
+    klass.send :define_method, :active_params_default_scope do
+      value
+    end
+    assert_equal nil, klass.new.active_params_writing?
+    assert_equal ENV.fetch("ACTIVE_PARAMS_PATH", "config/active_params.json"), klass.new.active_params_path
+    assert_equal value, klass.new.active_params_scope
   end
 
-  def test_strong_params_definition_for_string
-    assert_equal "123",
-      ActiveParams.strong_params_definition_for("123")
+  # `include ActiveParams.setup...`
+  def test_setup_writing
+    value = rand
+    klass = Class.new do
+      include ActiveParams.setup(writing: value)
+    end
+    assert_equal value, klass.new.active_params_writing?
   end
 
-  def test_strong_params_definition_for_array
-    assert_equal [],
-      ActiveParams.strong_params_definition_for([123, "123"])
+  def test_setup_path
+    value = rand
+    klass = Class.new do
+      include ActiveParams.setup(path: value)
+    end
+    assert_equal value, klass.new.active_params_path
   end
 
-  def test_strong_params_definition_for
-    assert_equal [:id, :name, contacts: [:name, :relation, contacts: [:relation, :name], addresses: [:label, :address]], interests: []],
-      ActiveParams.strong_params_definition_for({
-        id: rand,
-        name: "Lorem ipsum",
-        contacts: {
-          "0" => {
-            relation: "Friend",
-            name: "Bob",
-          },
-          "1" => {
-            relation: "Mother",
-            name: "Charlie",
-            contacts: {
-              "0" => {
-                relation: "Friend",
-                name: "David",
-              },
-              "1" => {
-                relation: "Friend",
-                name: "Ethan",
-              },
-            },
-            addresses: [
-              { label: "home", address: "123 Sesame Street, NY" },
-              { label: "work", address: "Lorem ipsum"},
-            ]
-          },
-        },
-        interests: [
-          "Running",
-          "Netflix",
-        ]
-      })
+  def test_setup_scope
+    value = rand
+    klass = Class.new do
+      include ActiveParams.setup(scope: proc { value })
+    end
+    assert_equal value, klass.new.active_params_scope
   end
 end

--- a/test/active_params_test.rb
+++ b/test/active_params_test.rb
@@ -6,17 +6,19 @@ class ActiveParamsTest < Minitest::Test
   end
 
   # `include ActiveParams`
-  def test_defalut
+  # `ActiveParams.config`
+  def test_default
     value = rand
     klass = Class.new do
+      def request; Struct.new(:method).new("GET"); end
+      def controller_name; "home"; end
+      def action_name; "index"; end
       include ActiveParams
     end
-    klass.send :define_method, :active_params_default_scope do
-      value
-    end
-    assert_equal nil, klass.new.active_params_writing?
-    assert_equal ENV.fetch("ACTIVE_PARAMS_PATH", "config/active_params.json"), klass.new.active_params_path
-    assert_equal value, klass.new.active_params_scope
+    instance = klass.new
+    assert_equal nil, instance.active_params_writing?
+    assert_equal ENV.fetch("ACTIVE_PARAMS_PATH", "config/active_params.json"), instance.active_params_path
+    assert_equal "GET home/index", instance.active_params_scope
   end
 
   # `include ActiveParams.setup...`


### PR DESCRIPTION
Fix #1 Fix #2

A rather big refactoring to allow for syntax like

``` ruby
class ApplicationController < ActionController::Base
  include ActiveParams.setup({
    path: "tmp/strong_params.json",
    writing: !Rails.env.production?,
    scope: proc {|ctrl|
      [ctrl.current_user.role, ctrl.active_params_default_scope].join('@')
    },
  })
end
```

while keeping

``` ruby
class ApplicationController < ActionController::Base
  include ActiveParams
end
```

@winston wdyt?
